### PR TITLE
Add List Tags Refinable Links sample

### DIFF
--- a/Results/Handlebars/List Tag options/ListTagOptions.md
+++ b/Results/Handlebars/List Tag options/ListTagOptions.md
@@ -20,3 +20,10 @@ The List Tags Advanced option looks like this, using the same style as seen in t
 
 ![Advanced](/Results/Handlebars/List%20Tag%20options/asserts/advanced_tags.png)
 
+## Refinable links layout ##
+The List Tags Refinable Links option is a new variant that keeps the pill style, but makes each tag open a target search page with a Search Filters refiner already selected.
+
+This variant is page-specific in practice. You must replace the page URL and the Search Filters web part instance ID with values from your own page.
+
+[List Tags Refinable Links](/Results/Handlebars/List%20Tags%20Refinable%20Links/ListTagsRefinableLinks.md)
+

--- a/Results/Handlebars/List Tags Refinable Links/List Tags Refinable Links.html
+++ b/Results/Handlebars/List Tags Refinable Links/List Tags Refinable Links.html
@@ -1,0 +1,230 @@
+<content id="data-content">
+
+    <style>
+        /*
+            Replace these placeholders before using the sample:
+            - __TARGET_PAGE_URL__
+            - __FILTERS_INSTANCE_ID__
+            - RefinableString109
+        */
+
+        .TagLink {
+            color: #ffffff;
+            text-decoration: none;
+            font-size: 14px;
+            font-weight: 400;
+            line-height: 1.5;
+            padding: 2px 5px 0 2px;
+            text-align: center;
+            white-space: nowrap;
+            overflow: hidden;
+        }
+
+        .TagPill {
+            background-color: {{@root.theme.palette.themePrimary}};
+            border-radius: 12px;
+            box-sizing: content-box;
+            color: #ffffff;
+            cursor: pointer;
+            display: flex;
+            flex-shrink: 1;
+            flex-wrap: nowrap;
+            height: 26px;
+            line-height: 26px;
+            margin: 4px 4px 6px;
+            max-width: 100%;
+            padding-left: 5px;
+            position: relative;
+            -webkit-user-select: none;
+            -ms-user-select: none;
+            user-select: none;
+        }
+
+        .example-themePrimary a {
+            color: {{@root.theme.palette.themePrimary}};
+        }
+
+        {{#unless @root.properties.layoutProperties.showItemThumbnail}}
+        .template--listItem--result {
+            flex-basis: 100% !important;
+        }
+        {{/unless}}
+    </style>
+
+    <div class="template">
+
+        {{#if @root.properties.showSelectedFilters}}
+        <pnp-selectedfilters data-filters="{{JSONstringify filters.selectedFilters 2}}" data-filters-configuration="{{JSONstringify filters.filtersConfiguration 2}}" data-instance-id="{{filters.instanceId}}" data-operator="{{filters.filterOperator}}" data-theme-variant="{{JSONstringify @root.theme}}">
+        </pnp-selectedfilters>
+        {{/if}}
+
+        <div class="template--header">
+            <div class="template--resultCount">
+                {{#if @root.properties.showResultsCount}}
+                <label class="ms-fontWeight-semibold">{{getCountMessage @root.data.totalItemsCount @root.inputQueryText}}</label>
+                {{/if}}
+            </div>
+
+            <div class="template--toolbar">
+                {{#and properties.layoutProperties.enableDownload @root.properties.itemSelectionProps.allowItemSelection}}
+                <pnp-download-selected-items-button
+                    data-items="{{JSONstringify data.items}}"
+                    data-context="{{JSONstringify (truncateContext @root)}}"
+                    data-theme-variant="{{JSONstringify @root.theme}}">
+                </pnp-download-selected-items-button>
+                {{/and}}
+
+                <div class="template--sort">
+                    <pnp-sortfield
+                        data-fields="{{JSONstringify @root.properties.dataSourceProperties.sortList}}"
+                        data-default-selected-field="{{sort.selectedSortFieldName}}"
+                        data-default-direction="{{sort.selectedSortDirection}}"
+                        data-theme-variant="{{JSONstringify @root.theme}}">
+                    </pnp-sortfield>
+                </div>
+            </div>
+        </div>
+
+        {{#if @root.data.promotedResults}}
+        <ul class="template--defaultList template--promotedResults">
+            {{#each @root.data.promotedResults as |promotedResult|}}
+            <li>
+                <div>
+                    <pnp-icon data-name="MiniLink" aria-hidden="true"></pnp-icon>
+                </div>
+                <div>
+                    <a href="{{url}}" style="color:{{@root.theme.semanticColors.link}}">{{title}}</a>
+                    <div>{{description}}</div>
+                </div>
+            </li>
+            {{/each}}
+        </ul>
+        {{/if}}
+
+        <ul class="template--defaultList">
+            {{#each data.items as |item|}}
+            <pnp-select
+                data-enabled="{{@root.properties.itemSelectionProps.allowItemSelection}}"
+                data-index="{{@index}}"
+                data-is-selected="{{isItemSelected @root.selectedKeys @index}}">
+
+                <template id="content">
+
+                    <li class="template--listItem">
+                        {{#> resultTypes item=item}}
+                        <div class="template--listItem--result">
+                            {{#if @root.properties.layoutProperties.showFileIcon}}
+                            {{#contains "['STS_Site','STS_Web']" (slot item @root.slots.contentclass)}}
+                            <pnp-iconfile class="template--listItem--icon" data-extension="{{slot item @root.slots.FileType}}" data-is-container="{{slot item @root.slots.IsFolder}}" data-image-url="{{item.SiteLogo}}" data-size="32" data-theme-variant="{{JSONstringify @root.theme}}"></pnp-iconfile>
+                            {{else}}
+                            <pnp-iconfile class="template--listItem--icon" data-extension="{{slot item @root.slots.FileType}}" data-is-container="{{slot item @root.slots.IsFolder}}" data-size="32" data-theme-variant="{{JSONstringify @root.theme}}"></pnp-iconfile>
+                            {{/contains}}
+                            {{/if}}
+
+                            <div class="template--listItem--contentContainer">
+                                <span class="template--listItem--title example-themePrimary">
+                                    <a href="{{slot item @root.slots.PreviewUrl}}" target="_blank" style="color:{{@root.theme.semanticColors.link}}" data-interception="off" rel="noopener noreferrer">{{slot item @root.slots.Title}}</a>
+                                </span>
+
+                                <span>
+                                    <span class="template--listItem--author">
+                                        {{#with (split (slot item @root.slots.Author) '|')}}
+                                        {{[1]}}
+                                        {{/with}}
+                                    </span>
+                                    <span class="template--listItem--date">{{getDate (slot item @root.slots.Date) "LL"}}</span>
+                                </span>
+
+                                <div>{{getSummary (slot item @root.slots.Summary)}}</div>
+
+                                <div class="template--listItem--tags example-themePrimary">
+                                    {{#if (slot item @root.slots.Tags)}}
+                                    <div style="justify-content: flex-start; display: flex; flex-wrap: wrap;">
+                                        {{#each (split (slot item @root.slots.Tags) "ǂǂ") as |tag|}}
+                                        {{#if (trim tag)}}
+                                        <div class="TagPill">
+                                            <a
+                                                class="TagLink"
+                                                href="__TARGET_PAGE_URL__?v=Cards&f___FILTERS_INSTANCE_ID__=%5B%7B%22filterName%22%3A%22RefinableString109%22%2C%22values%22%3A%5B%7B%22name%22%3A%22{{trim tag}}%22%2C%22value%22%3A%22%5C%22%C7%82%C7%82{{stringToHex (trim tag)}}%5C%22%22%2C%22operator%22%3A0%7D%5D%2C%22operator%22%3A%22or%22%7D%5D"
+                                                data-interception="off">{{trim tag}}</a>
+                                        </div>
+                                        {{/if}}
+                                        {{/each}}
+                                    </div>
+                                    {{/if}}
+                                </div>
+                            </div>
+                        </div>
+
+                        {{#if @root.properties.layoutProperties.showItemThumbnail}}
+                        <div class="template--listItem--thumbnailContainer" data-selection-disabled="true">
+                            <div class="thumbnail--image">
+                                <pnp-filepreview data-preview-url="{{slot item @root.slots.PreviewUrl}}" data-preview-image-url="{{slot item @root.slots.PreviewImageUrl}}" data-theme-variant="{{JSONstringify @root.theme}}">
+                                    <pnp-img alt="preview-image" width="120" src="{{slot item @root.slots.PreviewImageUrl}}" loading="lazy" data-error-image="{{@root.utils.defaultImage}}" />
+                                </pnp-filepreview>
+                                <div class="thumbnail--hover">
+                                    <div>
+                                        <pnp-icon data-name="DocumentSearch" aria-hidden="true"></pnp-icon>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        {{/if}}
+                        {{/resultTypes}}
+                    </li>
+                </template>
+            </pnp-select>
+            {{/each}}
+        </ul>
+
+        {{#if @root.properties.paging.showPaging}}
+        {{#gt @root.data.totalItemsCount @root.properties.paging.itemsCountPerPage}}
+        <pnp-pagination data-total-items="{{@root.data.totalItemsCount}}" data-hide-first-last-pages="{{@root.properties.paging.hideFirstLastPages}}" data-hide-disabled="{{@root.properties.paging.hideDisabled}}" data-hide-navigation="{{@root.properties.paging.hideNavigation}}"
+            data-range="{{@root.properties.paging.pagingRange}}" data-items-count-per-page="{{@root.properties.paging.itemsCountPerPage}}" data-current-page-number="{{@root.paging.currentPageNumber}}"
+            data-theme-variant="{{JSONstringify @root.theme}}">
+        </pnp-pagination>
+        {{/gt}}
+        {{/if}}
+
+    </div>
+</content>
+
+<content id="placeholder-content">
+    <style>
+        /* Insert your CSS overrides here */
+    </style>
+
+    <div class="placeholder">
+        {{#if @root.properties.showResultsCount}}
+        <div class="template--resultCount">
+            <span class="placeholder--shimmer placeholder--line" style="width: 20%"></span>
+        </div>
+        {{/if}}
+        <ul class="template--defaultList">
+            {{#times @root.properties.paging.itemsCountPerPage}}
+            <li class="template--listItem" tabindex="0">
+                <div class="template--listItem--result">
+                    {{#if @root.properties.layoutProperties.showFileIcon}}
+                    <div class="template--listItem--icon placeholder--shimmer"></div>
+                    {{/if}}
+                    <div class="template--listItem--contentContainer">
+                        <span class="placeholder--shimmer placeholder--line" style="width: 60%"></span>
+                        <span class="placeholder--shimmer placeholder--line" style="width: 100%"></span>
+                        <span class="placeholder--shimmer placeholder--line" style="width: 100%"></span>
+                        <span class="placeholder--shimmer placeholder--line" style="width: 35%"></span>
+                        <span class="placeholder--shimmer placeholder--line" style="width: 20%"></span>
+                    </div>
+                </div>
+                {{#if @root.properties.layoutProperties.showItemThumbnail}}
+                <div class="template--listItem--thumbnailContainer">
+                    <div class="thumbnail--image">
+                        <div class="placeholder--shimmer" style="width: 120px; height: 70px;"></div>
+                    </div>
+                </div>
+                {{/if}}
+            </li>
+            {{/times}}
+        </ul>
+    </div>
+
+</content>

--- a/Results/Handlebars/List Tags Refinable Links/ListTagsRefinableLinks.md
+++ b/Results/Handlebars/List Tags Refinable Links/ListTagsRefinableLinks.md
@@ -1,0 +1,60 @@
+# List Tags Refinable Links #
+
+This sample is a new variant of the list tag layouts. It keeps the tag-pill presentation, but turns each pill into a link that opens a Search Results page with a Search Filters refiner already selected.
+
+It does not replace the existing **List Tags Advanced options** sample. That sample should remain as-is. This variant is an additional option for scenarios where the tags should act as refiner links.
+
+## What this variant does
+
+- renders tags as pills
+- makes each pill clickable
+- opens a target search page with a preselected refiner
+- can also preserve a vertical by including a query parameter such as `v=Cards`
+
+This is possible because PnP Modern Search supports Search Filters deep links and provides the `stringToHex` Handlebars helper to build the encoded filter value.
+
+## Important limitation
+
+This sample is still not fully generic.
+
+In practice, you must still specify:
+
+- the page URL to open
+- the Search Filters web part instance ID used on that page
+
+The dynamic `f_{{@root.filters.instanceId}}` pattern can work for reusable templates when the Search Results template receives the connected Filters instance ID. However, that is not reliable in every page setup. For this sample, treat the layout as page-specific and replace both the page URL and the Search Filters instance ID with values from your own page.
+
+## How the deep link works
+
+The Search Filters web part stores selected filters in a query string parameter named `f_<Search Filters instance ID>`.
+
+For plain string refiners, each selected value uses the following structure:
+
+- `name`: the label displayed in the filter UI
+- `value`: the same label encoded as UTF-8 hex, prefixed with `ǂǂ`, then wrapped in escaped quotes
+- `operator`: typically `0`
+
+The safest way to produce a working URL is:
+
+1. Select the filter once in the UI.
+1. Copy the generated URL.
+1. Keep the page URL, the `f_<instanceId>` parameter name, and the JSON payload structure.
+1. Replace only the `name` and encoded `value` parts in the template.
+
+## Example
+
+The sample layout file is [List Tags Refinable Links](./List%20Tags%20Refinable%20Links.html).
+
+Before using it, replace all occurrences of these placeholders:
+
+- `__TARGET_PAGE_URL__` with your target page URL
+- `__FILTERS_INSTANCE_ID__` with your Search Filters web part instance ID
+- `RefinableString109` with the managed property used by your filter
+
+If your page depends on a selected vertical, keep or adjust the example `v=Cards` query parameter.
+
+## Notes
+
+- This example intentionally uses a page-specific link.
+- If you use taxonomy refiners instead of plain string refiners, the filter `value` format is different and must use the taxonomy token format from a generated Search Filters URL.
+- When possible, copy a working URL from the UI instead of hand-authoring the full payload.


### PR DESCRIPTION
## Summary
- add a new `List Tags Refinable Links` Handlebars sample for list tag layouts
- keep the existing `List Tags Advanced options` sample unchanged
- document the new sample as an additional variant under the list tag options page
- include a working page-specific refiner-pill pattern based on Search Filters deep links
- call out the current limitation that the sample still requires both the target page URL and the Search Filters web part instance ID

## Details
This PR adds a new sample that renders tags as clickable pills and opens a target search page with a preselected Search Filters refiner.

The sample is intentionally documented as page-specific. In its current form, it still requires:
- a target page URL
- a Search Filters web part instance ID
- the managed property used by the target filter

It does not replace the existing advanced tag layout. It is a separate option for scenarios where tags should behave like refiner links.

## Files
- adds `Results/Handlebars/List Tags Refinable Links/ListTagsRefinableLinks.md`
- adds `Results/Handlebars/List Tags Refinable Links/List Tags Refinable Links.html`
- updates `Results/Handlebars/List Tag options/ListTagOptions.md`

## Testing
- documentation/sample only
- verified the new sample and index update locally